### PR TITLE
POC: Add linked mailbox test for directory service

### DIFF
--- a/payjoin-mailroom/src/directory.rs
+++ b/payjoin-mailroom/src/directory.rs
@@ -280,7 +280,9 @@ impl<D: Db> Service<D> {
             return Err(HandlerError::PayloadTooLarge);
         }
         match self.db.post_v2_payload(&id, req.into()).await {
-            Ok(_) => Ok(none_response),
+            Ok(Some(())) => Ok(none_response),
+            // A different payload already occupies this short_id.
+            Ok(None) => Ok(Response::builder().status(StatusCode::CONFLICT).body(empty())?),
             Err(e) => Err(HandlerError::InternalServerError(e.into())),
         }
     }

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -62,7 +62,9 @@ web-time = "1.1.0"
 ignored = ["bitcoin-units"]
 
 [dev-dependencies]
+async-stream = "0.3.6"
 bhttp = "0.6.1"
+futures = "0.3.31"
 ohttp = { package = "bitcoin-ohttp", version = "0.6.0" }
 once_cell = "1.21.3"
 payjoin-test-utils = { version = "0.0.1" }

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -62,6 +62,8 @@ web-time = "1.1.0"
 ignored = ["bitcoin-units"]
 
 [dev-dependencies]
+bhttp = "0.6.1"
+ohttp = { package = "bitcoin-ohttp", version = "0.6.0" }
 once_cell = "1.21.3"
 payjoin-test-utils = { version = "0.0.1" }
 tokio = { version = "1.47.1", features = ["full"] }

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -35,11 +35,12 @@ directory = []
 v1 = ["_core"]
 v2 = ["_core", "hpke", "bhttp", "ohttp", "directory"]
 #[doc = "Functions to fetch OHTTP keys via CONNECT proxy using reqwest. Enables `v2` since only `v2` uses OHTTP."]
-io = ["v2", "reqwest/rustls-tls"]
+io = ["v2", "reqwest/rustls-tls", "dep:futures"]
 _manual-tls = ["rustls"]
 
 [dependencies]
 bhttp = { version = "0.6.1", optional = true }
+futures = { version = "0.3.31", default-features = false, features = ["std"], optional = true }
 bitcoin = { version = "0.32.7", features = ["base64"] }
 bitcoin-units = "0.1.3"
 bitcoin_uri = { version = "0.1.0", optional = true }

--- a/payjoin/src/core/linked_mailbox.rs
+++ b/payjoin/src/core/linked_mailbox.rs
@@ -1,0 +1,194 @@
+//! Append-only broadcast channel over Payjoin Directory mailboxes.
+//!
+//! Multiple peers sharing a secret can write concurrently. Concurrent writers
+//! converge on distinct slots because the directory returns 409 on an occupied
+//! mailbox; the writer then advances to the next slot and retries.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use bitcoin::hashes::{sha256, Hash, HashEngine};
+use futures::{stream, Stream};
+
+use crate::directory::{ShortId, ENCAPSULATED_MESSAGE_BYTES};
+use crate::ohttp::{ohttp_decapsulate, ohttp_encapsulate};
+use crate::OhttpKeys;
+
+fn generate_short_id(shared_secret: &[u8], index: u64) -> ShortId {
+    let mut engine = sha256::Hash::engine();
+    engine.input(b"v0-PayjoinDirectoryEntry");
+    engine.input(shared_secret);
+    engine.input(index.to_le_bytes().as_slice());
+    sha256::Hash::from_engine(engine).into()
+}
+
+type MailboxError = Box<dyn std::error::Error + Send + Sync>;
+
+async fn raw_write(
+    client: &reqwest::Client,
+    gateway_url: &str,
+    directory_url: &str,
+    ohttp_keys: &OhttpKeys,
+    short_id: ShortId,
+    message: &[u8],
+) -> Result<http::StatusCode, MailboxError> {
+    let target = format!("{directory_url}/{short_id}");
+    let (req, ohttp_ctx) = ohttp_encapsulate(ohttp_keys, "POST", &target, Some(message))
+        .map_err(|e| std::io::Error::other(format!("OHTTP encapsulation error: {e}")))?;
+    let body = client
+        .post(gateway_url)
+        .header("Content-Type", "message/ohttp-req")
+        .body(req.to_vec())
+        .send()
+        .await?
+        .bytes()
+        .await?;
+    let body_arr: &[u8; ENCAPSULATED_MESSAGE_BYTES] = body
+        .as_ref()
+        .try_into()
+        .map_err(|_| std::io::Error::other("unexpected relay response size"))?;
+    let res = ohttp_decapsulate(ohttp_ctx, body_arr)
+        .map_err(|e| std::io::Error::other(format!("OHTTP decapsulation error: {e}")))?;
+    Ok(res.status())
+}
+
+async fn raw_read(
+    client: &reqwest::Client,
+    gateway_url: &str,
+    directory_url: &str,
+    ohttp_keys: &OhttpKeys,
+    short_id: ShortId,
+) -> Result<Option<Vec<u8>>, MailboxError> {
+    let target = format!("{directory_url}/{short_id}");
+    let (req, ohttp_ctx) = ohttp_encapsulate(ohttp_keys, "GET", &target, None)
+        .map_err(|e| std::io::Error::other(format!("OHTTP encapsulation error: {e}")))?;
+    let body = client
+        .post(gateway_url)
+        .header("Content-Type", "message/ohttp-req")
+        .body(req.to_vec())
+        .send()
+        .await?
+        .bytes()
+        .await?;
+    let body_arr: &[u8; ENCAPSULATED_MESSAGE_BYTES] = body
+        .as_ref()
+        .try_into()
+        .map_err(|_| std::io::Error::other("unexpected relay response size"))?;
+    let res = ohttp_decapsulate(ohttp_ctx, body_arr)
+        .map_err(|e| std::io::Error::other(format!("OHTTP decapsulation error: {e}")))?;
+    match res.status() {
+        http::StatusCode::OK => Ok(Some(res.into_body())),
+        http::StatusCode::ACCEPTED => Ok(None),
+        s => Err(std::io::Error::other(format!("unexpected directory status: {s}")).into()),
+    }
+}
+
+/// Append-only broadcast channel shared by multiple participants.
+///
+/// Each participant is initialized with the same shared secret.
+#[allow(async_fn_in_trait)]
+pub trait CollaborativeMessageSet {
+    type Message;
+    type Error;
+
+    type Messages<'a>: Stream<Item = Result<Self::Message, Self::Error>> + Send + 'a
+    where
+        Self: 'a;
+
+    /// Append one complete message.
+    async fn write(&self, message: Self::Message) -> Result<(), Self::Error>;
+
+    /// Read all messages from the beginning in server-determined order.
+    fn read(&self) -> Self::Messages<'_>;
+}
+
+/// [`CollaborativeMessageSet`] over a chain of Payjoin Directory mailboxes.
+///
+/// `short_id(i) = H("v0-PayjoinDirectoryEntry" || shared_secret || i)`.
+/// `write` walks forward on 409 so concurrent writers converge on distinct
+/// slots. `read` polls each slot in order and stops when the directory's
+/// wait timeout elapses without a payload.
+pub struct DirectoryLinkedMailbox {
+    client: reqwest::Client,
+    /// Full relay gateway URL, e.g. `http://relay/{directory_url}`.
+    gateway_url: String,
+    /// Base URL of the directory, e.g. `https://payjo.in`.
+    directory_url: String,
+    ohttp_keys: OhttpKeys,
+    shared_secret: [u8; 32],
+    next_write_index: AtomicU64,
+}
+
+impl DirectoryLinkedMailbox {
+    pub fn new(
+        client: reqwest::Client,
+        gateway_url: String,
+        directory_url: String,
+        ohttp_keys: OhttpKeys,
+        shared_secret: [u8; 32],
+    ) -> Self {
+        Self {
+            client,
+            gateway_url,
+            directory_url,
+            ohttp_keys,
+            shared_secret,
+            next_write_index: AtomicU64::new(0),
+        }
+    }
+}
+
+impl CollaborativeMessageSet for DirectoryLinkedMailbox {
+    type Message = Vec<u8>;
+    type Error = MailboxError;
+    type Messages<'a> =
+        std::pin::Pin<Box<dyn Stream<Item = Result<Vec<u8>, MailboxError>> + Send + 'a>>;
+
+    async fn write(&self, message: Vec<u8>) -> Result<(), Self::Error> {
+        let mut i = self.next_write_index.load(Ordering::Relaxed);
+        loop {
+            let short_id = generate_short_id(&self.shared_secret, i);
+            match raw_write(
+                &self.client,
+                &self.gateway_url,
+                &self.directory_url,
+                &self.ohttp_keys,
+                short_id,
+                &message,
+            )
+            .await?
+            {
+                http::StatusCode::OK => {
+                    self.next_write_index.fetch_max(i + 1, Ordering::Relaxed);
+                    return Ok(());
+                }
+                http::StatusCode::CONFLICT => i += 1,
+                s =>
+                    return Err(
+                        std::io::Error::other(format!("unexpected write status: {s}")).into()
+                    ),
+            }
+        }
+    }
+
+    fn read(&self) -> Self::Messages<'_> {
+        let secret = self.shared_secret;
+        let client = self.client.clone();
+        let gateway_url = self.gateway_url.clone();
+        let directory_url = self.directory_url.clone();
+        let ohttp_keys = self.ohttp_keys.clone();
+        Box::pin(stream::try_unfold(0u64, move |i| {
+            let client = client.clone();
+            let gateway_url = gateway_url.clone();
+            let directory_url = directory_url.clone();
+            let ohttp_keys = ohttp_keys.clone();
+            async move {
+                let short_id = generate_short_id(&secret, i);
+                match raw_read(&client, &gateway_url, &directory_url, &ohttp_keys, short_id).await?
+                {
+                    Some(payload) => Ok(Some((payload, i + 1))),
+                    None => Ok(None),
+                }
+            }
+        }))
+    }
+}

--- a/payjoin/src/core/mod.rs
+++ b/payjoin/src/core/mod.rs
@@ -42,6 +42,9 @@ pub use crate::ohttp::OhttpKeys;
 #[cfg(feature = "io")]
 #[cfg_attr(docsrs, doc(cfg(feature = "io")))]
 pub mod io;
+#[cfg(feature = "io")]
+#[cfg_attr(docsrs, doc(cfg(feature = "io")))]
+pub mod linked_mailbox;
 
 /// 4M block size limit with base64 encoding overhead => maximum reasonable size of content-length
 /// 4_000_000 * 4 / 3 fits in u32

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -191,14 +191,13 @@ mod integration {
     // not all needs v1
     #[cfg(all(feature = "io", feature = "v2", feature = "v1", feature = "_manual-tls"))]
     mod v2 {
-        // use std::random;
         use std::sync::Arc;
         use std::time::Duration;
 
-        use bitcoin::hashes::{sha256, Hash, HashEngine};
         use bitcoin::{secp256k1, Address, Transaction};
         use hpke::rand_core::OsRng;
         use http::StatusCode;
+        use payjoin::linked_mailbox::{CollaborativeMessageSet, DirectoryLinkedMailbox};
         use payjoin::persist::OptionalTransitionOutcome;
         use payjoin::receive::v2::{
             replay_event_log as replay_receiver_event_log, Monitor, PayjoinProposal,
@@ -224,219 +223,20 @@ mod integration {
             BroadcastFallbackTransaction,
         }
 
-        // Generate a short id based on shared secret and index
-        fn generate_short_id(shared_secret: &[u8], index: u64) -> payjoin::directory::ShortId {
-            let mut engine = sha256::Hash::engine();
-            engine.input(b"v0-PayjoinDirectoryEntry");
-            engine.input(shared_secret);
-            engine.input(index.to_le_bytes().as_slice());
-            sha256::Hash::from_engine(engine).into()
-        }
-
-        // Padding sized to match payjoin/src/core/ohttp.rs:
-        // ENCAPSULATED_MESSAGE_BYTES - (N_ENC=65 + N_T=16 + OHTTP_REQ_HEADER_BYTES=7)
-        const PADDED_BHTTP_REQ_BYTES: usize =
-            payjoin::directory::ENCAPSULATED_MESSAGE_BYTES - (65 + 16 + 7);
-
-        fn encapsulate_request(
-            ohttp_keys: &payjoin::OhttpKeys,
-            method: &str,
-            target_url: &str,
-            body: Option<&[u8]>,
-        ) -> Result<(Vec<u8>, ohttp::ClientResponse), BoxSendSyncError> {
-            let mut config = ohttp_keys.0.clone();
-            let ctx = ohttp::ClientRequest::from_config(&mut config)?;
-            let url = payjoin::Url::parse(target_url)?;
-            let authority = match url.port() {
-                Some(p) => format!("{}:{}", url.host_str(), p),
-                None => url.host_str(),
-            };
-            let mut bhttp_msg = bhttp::Message::request(
-                method.as_bytes().to_vec(),
-                url.scheme().as_bytes().to_vec(),
-                authority.into_bytes(),
-                url.path().as_bytes().to_vec(),
-            );
-            if let Some(b) = body {
-                bhttp_msg.write_content(b);
-            }
-            let mut bhttp_buf = vec![0u8; PADDED_BHTTP_REQ_BYTES];
-            bhttp_msg.write_bhttp(bhttp::Mode::KnownLength, &mut bhttp_buf.as_mut_slice())?;
-            let (encapsulated, ohttp_ctx) = ctx.encapsulate(&bhttp_buf)?;
-            Ok((encapsulated, ohttp_ctx))
-        }
-
-        fn decapsulate_response(
-            ohttp_ctx: ohttp::ClientResponse,
-            encapsulated: &[u8],
-        ) -> Result<(http::StatusCode, Vec<u8>), BoxSendSyncError> {
-            let bhttp_bytes = ohttp_ctx.decapsulate(encapsulated)?;
-            let mut cursor = std::io::Cursor::new(bhttp_bytes);
-            let msg = bhttp::Message::read_bhttp(&mut cursor)?;
-            let code = msg.control().status().ok_or("missing status")?.code();
-            let status = http::StatusCode::from_u16(code)?;
-            Ok((status, msg.content().to_vec()))
-        }
-
-        // The relay extracts the gateway URI from its request path; embed the
-        // directory URL there (matches `SessionContext::full_relay_url`).
-        fn relay_url_for_directory(services: &TestServices) -> String {
-            format!("{}/{}", services.ohttp_relay_url(), services.directory_url())
-        }
-
-        async fn write_mailbox(
+        fn make_mailbox(
             services: &TestServices,
-            ohttp_keys: &payjoin::OhttpKeys,
-            short_id: payjoin::directory::ShortId,
-            message: &[u8],
-        ) -> Result<http::StatusCode, BoxSendSyncError> {
-            let target = format!("{}/{}", services.directory_url(), short_id);
-            let (req, ohttp_ctx) = encapsulate_request(ohttp_keys, "POST", &target, Some(message))?;
-            let response = services
-                .http_agent()
-                .post(relay_url_for_directory(services))
-                .header("Content-Type", "message/ohttp-req")
-                .body(req)
-                .send()
-                .await?;
-            assert!(response.status().is_success(), "relay status: {}", response.status());
-            let body = response.bytes().await?;
-            let (status, _) = decapsulate_response(ohttp_ctx, &body)?;
-            Ok(status)
-        }
-
-        async fn read_mailbox(
-            services: &TestServices,
-            ohttp_keys: &payjoin::OhttpKeys,
-            short_id: payjoin::directory::ShortId,
-        ) -> Result<Option<Vec<u8>>, BoxSendSyncError> {
-            let target = format!("{}/{}", services.directory_url(), short_id);
-            let (req, ohttp_ctx) = encapsulate_request(ohttp_keys, "GET", &target, None)?;
-            let response = services
-                .http_agent()
-                .post(relay_url_for_directory(services))
-                .header("Content-Type", "message/ohttp-req")
-                .body(req)
-                .send()
-                .await?;
-            assert!(response.status().is_success(), "relay status: {}", response.status());
-            let body = response.bytes().await?;
-            let (status, content) = decapsulate_response(ohttp_ctx, &body)?;
-            match status {
-                http::StatusCode::OK => Ok(Some(content)),
-                http::StatusCode::ACCEPTED => Ok(None),
-                other => Err(format!("unexpected get_mailbox status: {}", other).into()),
-            }
-        }
-
-        /// Append-only broadcast channel shared by multiple participants.
-        ///
-        /// Each participant is initialized with the same shared identity.
-        trait CollaborativeMessageSet {
-            type Message;
-            type Error;
-
-            type Messages<'a>: futures::Stream<Item = Result<Self::Message, Self::Error>>
-                + Send
-                + 'a
-            where
-                Self: 'a;
-
-            /// Append one complete message.
-            async fn write(&self, message: Self::Message) -> Result<(), Self::Error>;
-
-            /// Read all messages from the beginning in server-determined order.
-            fn read(&self) -> Self::Messages<'_>;
-        }
-
-        /// `CollaborativeMessageSet` over a chain of directory mailboxes.
-        ///
-        /// `short_id(i) = H(shared_secret, i)`. `write` walks forward on 409
-        /// so concurrent writers converge on distinct slots without
-        /// coordinating an index out-of-band. `read` polls each slot in
-        /// order and stops when the directory's local wait timeout elapses
-        /// without a payload.
-        struct DirectoryLinkedMailbox<'a> {
-            services: &'a TestServices,
-            ohttp_keys: &'a payjoin::OhttpKeys,
+            ohttp_keys: &OhttpKeys,
             shared_secret: [u8; 32],
-            // Local-only hint for this peer; it starts at 0 and never
-            // decreases. Different peers do not share this hint, so each
-            // peer races forward independently and relies on the directory's
-            // 409 to resolve concurrent collisions.
-            next_write_index: std::sync::atomic::AtomicU64,
-        }
-
-        impl<'a> DirectoryLinkedMailbox<'a> {
-            fn new(
-                services: &'a TestServices,
-                ohttp_keys: &'a payjoin::OhttpKeys,
-                shared_secret: [u8; 32],
-            ) -> Self {
-                Self {
-                    services,
-                    ohttp_keys,
-                    shared_secret,
-                    next_write_index: std::sync::atomic::AtomicU64::new(0),
-                }
-            }
-        }
-
-        impl<'a> CollaborativeMessageSet for DirectoryLinkedMailbox<'a> {
-            type Message = Vec<u8>;
-            type Error = BoxSendSyncError;
-            type Messages<'b>
-                = std::pin::Pin<
-                Box<dyn futures::Stream<Item = Result<Vec<u8>, BoxSendSyncError>> + Send + 'b>,
-            >
-            where
-                Self: 'b;
-
-            async fn write(&self, message: Vec<u8>) -> Result<(), Self::Error> {
-                use std::sync::atomic::Ordering;
-                let mut i = self.next_write_index.load(Ordering::Relaxed);
-                loop {
-                    let short_id = generate_short_id(&self.shared_secret, i);
-                    let status =
-                        write_mailbox(self.services, self.ohttp_keys, short_id, &message).await?;
-                    match status {
-                        http::StatusCode::OK => {
-                            // Advance the local hint past the slot we just claimed.
-                            self.next_write_index.fetch_max(i + 1, Ordering::Relaxed);
-                            return Ok(());
-                        }
-                        http::StatusCode::CONFLICT => {
-                            i += 1;
-                        }
-                        other =>
-                            return Err(format!("unexpected post_mailbox status: {}", other).into()),
-                    }
-                }
-            }
-
-            fn read(&self) -> Self::Messages<'_> {
-                let secret = self.shared_secret;
-                let services = self.services;
-                let keys = self.ohttp_keys;
-                Box::pin(async_stream::stream! {
-                    let mut i = 0u64;
-                    loop {
-                        let short_id = generate_short_id(&secret, i);
-                        match read_mailbox(services, keys, short_id).await {
-                            Ok(Some(payload)) => {
-                                yield Ok(payload);
-                                i += 1;
-                            }
-                            // Local timeout: no payload at this slot. Could be true end-of-log.
-                            Ok(None) => break,
-                            Err(e) => {
-                                yield Err(e);
-                                break;
-                            }
-                        }
-                    }
-                })
-            }
+        ) -> DirectoryLinkedMailbox {
+            let gateway_url =
+                format!("{}/{}", services.ohttp_relay_url(), services.directory_url());
+            DirectoryLinkedMailbox::new(
+                (*services.http_agent()).clone(),
+                gateway_url,
+                services.directory_url(),
+                ohttp_keys.clone(),
+                shared_secret,
+            )
         }
 
         async fn do_linked_mailbox_test(services: &TestServices) -> Result<(), BoxSendSyncError> {
@@ -447,9 +247,9 @@ mod integration {
             let shared_secret = secp256k1::SecretKey::new(&mut OsRng).secret_bytes();
 
             // Each peer is independently initialized with only the shared secret.
-            let alice = DirectoryLinkedMailbox::new(services, &ohttp_keys, shared_secret);
-            let bob = DirectoryLinkedMailbox::new(services, &ohttp_keys, shared_secret);
-            let carol = DirectoryLinkedMailbox::new(services, &ohttp_keys, shared_secret);
+            let alice = make_mailbox(services, &ohttp_keys, shared_secret);
+            let bob = make_mailbox(services, &ohttp_keys, shared_secret);
+            let carol = make_mailbox(services, &ohttp_keys, shared_secret);
 
             let alice_msg = b"Hello from Alice".to_vec();
             let bob_msg = b"Hello from Bob".to_vec();
@@ -481,7 +281,7 @@ mod integration {
 
             // A peer initialized with a different secret sees an empty message set.
             let other_secret = secp256k1::SecretKey::new(&mut OsRng).secret_bytes();
-            let stranger = DirectoryLinkedMailbox::new(services, &ohttp_keys, other_secret);
+            let stranger = make_mailbox(services, &ohttp_keys, other_secret);
             let stranger_stream = stranger.read();
             tokio::pin!(stranger_stream);
             assert!(stranger_stream.next().await.is_none(), "unrelated message set must be empty");

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -227,6 +227,7 @@ mod integration {
         // Generate a short id based on shared secret and index
         fn generate_short_id(shared_secret: &[u8], index: u64) -> payjoin::directory::ShortId {
             let mut engine = sha256::Hash::engine();
+            engine.input(b"v0-PayjoinDirectoryEntry");
             engine.input(shared_secret);
             engine.input(index.to_le_bytes().as_slice());
             sha256::Hash::from_engine(engine).into()

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -191,10 +191,13 @@ mod integration {
     // not all needs v1
     #[cfg(all(feature = "io", feature = "v2", feature = "v1", feature = "_manual-tls"))]
     mod v2 {
+        // use std::random;
         use std::sync::Arc;
         use std::time::Duration;
 
-        use bitcoin::{Address, Transaction};
+        use bitcoin::hashes::{sha256, Hash, HashEngine};
+        use bitcoin::{secp256k1, Address, Transaction};
+        use hpke::rand_core::OsRng;
         use http::StatusCode;
         use payjoin::persist::OptionalTransitionOutcome;
         use payjoin::receive::v2::{
@@ -219,6 +222,168 @@ mod integration {
         enum SenderFinalAction {
             SignAndBroadcastPayjoinProposal,
             BroadcastFallbackTransaction,
+        }
+
+        // Generate a short id based on shared secret and index
+        fn generate_short_id(shared_secret: &[u8], index: u64) -> payjoin::directory::ShortId {
+            let mut engine = sha256::Hash::engine();
+            engine.input(shared_secret);
+            engine.input(index.to_le_bytes().as_slice());
+            sha256::Hash::from_engine(engine).into()
+        }
+
+        // Padding sized to match payjoin/src/core/ohttp.rs:
+        // ENCAPSULATED_MESSAGE_BYTES - (N_ENC=65 + N_T=16 + OHTTP_REQ_HEADER_BYTES=7)
+        const PADDED_BHTTP_REQ_BYTES: usize =
+            payjoin::directory::ENCAPSULATED_MESSAGE_BYTES - (65 + 16 + 7);
+
+        fn encapsulate_request(
+            ohttp_keys: &payjoin::OhttpKeys,
+            method: &str,
+            target_url: &str,
+            body: Option<&[u8]>,
+        ) -> Result<(Vec<u8>, ohttp::ClientResponse), BoxSendSyncError> {
+            let mut config = ohttp_keys.0.clone();
+            let ctx = ohttp::ClientRequest::from_config(&mut config)?;
+            let url = payjoin::Url::parse(target_url)?;
+            let authority = match url.port() {
+                Some(p) => format!("{}:{}", url.host_str(), p),
+                None => url.host_str(),
+            };
+            let mut bhttp_msg = bhttp::Message::request(
+                method.as_bytes().to_vec(),
+                url.scheme().as_bytes().to_vec(),
+                authority.into_bytes(),
+                url.path().as_bytes().to_vec(),
+            );
+            if let Some(b) = body {
+                bhttp_msg.write_content(b);
+            }
+            let mut bhttp_buf = vec![0u8; PADDED_BHTTP_REQ_BYTES];
+            bhttp_msg.write_bhttp(bhttp::Mode::KnownLength, &mut bhttp_buf.as_mut_slice())?;
+            let (encapsulated, ohttp_ctx) = ctx.encapsulate(&bhttp_buf)?;
+            Ok((encapsulated, ohttp_ctx))
+        }
+
+        fn decapsulate_response(
+            ohttp_ctx: ohttp::ClientResponse,
+            encapsulated: &[u8],
+        ) -> Result<(http::StatusCode, Vec<u8>), BoxSendSyncError> {
+            let bhttp_bytes = ohttp_ctx.decapsulate(encapsulated)?;
+            let mut cursor = std::io::Cursor::new(bhttp_bytes);
+            let msg = bhttp::Message::read_bhttp(&mut cursor)?;
+            let code = msg.control().status().ok_or("missing status")?.code();
+            let status = http::StatusCode::from_u16(code)?;
+            Ok((status, msg.content().to_vec()))
+        }
+
+        // The relay extracts the gateway URI from its request path; embed the
+        // directory URL there (matches `SessionContext::full_relay_url`).
+        fn relay_url_for_directory(services: &TestServices) -> String {
+            format!("{}/{}", services.ohttp_relay_url(), services.directory_url())
+        }
+
+        async fn write_mailbox(
+            services: &TestServices,
+            ohttp_keys: &payjoin::OhttpKeys,
+            short_id: payjoin::directory::ShortId,
+            message: &[u8],
+        ) -> Result<(), BoxSendSyncError> {
+            let target = format!("{}/{}", services.directory_url(), short_id);
+            let (req, ohttp_ctx) = encapsulate_request(ohttp_keys, "POST", &target, Some(message))?;
+            let response = services
+                .http_agent()
+                .post(relay_url_for_directory(services))
+                .header("Content-Type", "message/ohttp-req")
+                .body(req)
+                .send()
+                .await?;
+            assert!(response.status().is_success(), "relay status: {}", response.status());
+            let body = response.bytes().await?;
+            let (status, _) = decapsulate_response(ohttp_ctx, &body)?;
+            assert_eq!(status, http::StatusCode::OK, "post_mailbox status");
+            Ok(())
+        }
+
+        async fn read_mailbox(
+            services: &TestServices,
+            ohttp_keys: &payjoin::OhttpKeys,
+            short_id: payjoin::directory::ShortId,
+        ) -> Result<Option<Vec<u8>>, BoxSendSyncError> {
+            let target = format!("{}/{}", services.directory_url(), short_id);
+            let (req, ohttp_ctx) = encapsulate_request(ohttp_keys, "GET", &target, None)?;
+            let response = services
+                .http_agent()
+                .post(relay_url_for_directory(services))
+                .header("Content-Type", "message/ohttp-req")
+                .body(req)
+                .send()
+                .await?;
+            assert!(response.status().is_success(), "relay status: {}", response.status());
+            let body = response.bytes().await?;
+            let (status, content) = decapsulate_response(ohttp_ctx, &body)?;
+            match status {
+                http::StatusCode::OK => Ok(Some(content)),
+                http::StatusCode::ACCEPTED => Ok(None),
+                other => Err(format!("unexpected get_mailbox status: {}", other).into()),
+            }
+        }
+
+        async fn do_linked_mailbox_test(services: &TestServices) -> Result<(), BoxSendSyncError> {
+            services.wait_for_services_ready().await?;
+            let ohttp_keys = services.fetch_ohttp_keys().await?;
+
+            let shared_secret = secp256k1::SecretKey::new(&mut OsRng).secret_bytes();
+            let short_id_0 = generate_short_id(&shared_secret, 0);
+            let short_id_1 = generate_short_id(&shared_secret, 1);
+            let short_id_2 = generate_short_id(&shared_secret, 2);
+            assert_ne!(short_id_0, short_id_1);
+            assert_ne!(short_id_1, short_id_2);
+            assert_ne!(short_id_0, short_id_2);
+
+            let alice_msg: &[u8] = b"Hello from Alice";
+            let bob_msg: &[u8] = b"Hello from Bob";
+            let carol_msg: &[u8] = b"Hello from Carol";
+
+            write_mailbox(services, &ohttp_keys, short_id_0, alice_msg).await?;
+            write_mailbox(services, &ohttp_keys, short_id_1, bob_msg).await?;
+            write_mailbox(services, &ohttp_keys, short_id_2, carol_msg).await?;
+
+            let alice_read = read_mailbox(services, &ohttp_keys, short_id_0)
+                .await?
+                .ok_or("Alice's mailbox should have a payload")?;
+            let bob_read = read_mailbox(services, &ohttp_keys, short_id_1)
+                .await?
+                .ok_or("Bob's mailbox should have a payload")?;
+            let carol_read = read_mailbox(services, &ohttp_keys, short_id_2)
+                .await?
+                .ok_or("Carol's mailbox should have a payload")?;
+
+            assert_eq!(alice_read, alice_msg);
+            assert_eq!(bob_read, bob_msg);
+            assert_eq!(carol_read, carol_msg);
+
+            // An unrelated short_id (different shared secret) should have no payload posted.
+            let other_secret = secp256k1::SecretKey::new(&mut OsRng).secret_bytes();
+            let other_short_id = generate_short_id(&other_secret, 0);
+            let empty = read_mailbox(services, &ohttp_keys, other_short_id).await?;
+            assert!(empty.is_none(), "unrelated mailbox should be empty");
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_create_linked_mailbox() -> Result<(), BoxSendSyncError> {
+            init_tracing();
+            let mut services = TestServices::initialize().await?;
+            // 3 peers write to a linked sequence of mailboxes whose short_ids are
+            // derived as short_id = H(shared_secret, i) for i = 0..n.
+            let result = tokio::select!(
+                err = services.take_ohttp_relay_handle() => panic!("Ohttp relay exited early: {:?}", err),
+                err = services.take_directory_handle() => panic!("Directory server exited early: {:?}", err),
+                res = do_linked_mailbox_test(&services) => res
+            );
+            result
         }
 
         #[tokio::test]

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -288,7 +288,7 @@ mod integration {
             ohttp_keys: &payjoin::OhttpKeys,
             short_id: payjoin::directory::ShortId,
             message: &[u8],
-        ) -> Result<(), BoxSendSyncError> {
+        ) -> Result<http::StatusCode, BoxSendSyncError> {
             let target = format!("{}/{}", services.directory_url(), short_id);
             let (req, ohttp_ctx) = encapsulate_request(ohttp_keys, "POST", &target, Some(message))?;
             let response = services
@@ -301,8 +301,7 @@ mod integration {
             assert!(response.status().is_success(), "relay status: {}", response.status());
             let body = response.bytes().await?;
             let (status, _) = decapsulate_response(ohttp_ctx, &body)?;
-            assert_eq!(status, http::StatusCode::OK, "post_mailbox status");
-            Ok(())
+            Ok(status)
         }
 
         async fn read_mailbox(
@@ -329,45 +328,162 @@ mod integration {
             }
         }
 
+        /// Append-only broadcast channel shared by multiple participants.
+        ///
+        /// Each participant is initialized with the same shared identity.
+        trait CollaborativeMessageSet {
+            type Message;
+            type Error;
+
+            type Messages<'a>: futures::Stream<Item = Result<Self::Message, Self::Error>>
+                + Send
+                + 'a
+            where
+                Self: 'a;
+
+            /// Append one complete message.
+            async fn write(&self, message: Self::Message) -> Result<(), Self::Error>;
+
+            /// Read all messages from the beginning in server-determined order.
+            fn read(&self) -> Self::Messages<'_>;
+        }
+
+        /// `CollaborativeMessageSet` over a chain of directory mailboxes.
+        ///
+        /// `short_id(i) = H(shared_secret, i)`. `write` walks forward on 409
+        /// so concurrent writers converge on distinct slots without
+        /// coordinating an index out-of-band. `read` polls each slot in
+        /// order and stops when the directory's local wait timeout elapses
+        /// without a payload.
+        struct DirectoryLinkedMailbox<'a> {
+            services: &'a TestServices,
+            ohttp_keys: &'a payjoin::OhttpKeys,
+            shared_secret: [u8; 32],
+            // Local-only hint for this peer; it starts at 0 and never
+            // decreases. Different peers do not share this hint, so each
+            // peer races forward independently and relies on the directory's
+            // 409 to resolve concurrent collisions.
+            next_write_index: std::sync::atomic::AtomicU64,
+        }
+
+        impl<'a> DirectoryLinkedMailbox<'a> {
+            fn new(
+                services: &'a TestServices,
+                ohttp_keys: &'a payjoin::OhttpKeys,
+                shared_secret: [u8; 32],
+            ) -> Self {
+                Self {
+                    services,
+                    ohttp_keys,
+                    shared_secret,
+                    next_write_index: std::sync::atomic::AtomicU64::new(0),
+                }
+            }
+        }
+
+        impl<'a> CollaborativeMessageSet for DirectoryLinkedMailbox<'a> {
+            type Message = Vec<u8>;
+            type Error = BoxSendSyncError;
+            type Messages<'b>
+                = std::pin::Pin<
+                Box<dyn futures::Stream<Item = Result<Vec<u8>, BoxSendSyncError>> + Send + 'b>,
+            >
+            where
+                Self: 'b;
+
+            async fn write(&self, message: Vec<u8>) -> Result<(), Self::Error> {
+                use std::sync::atomic::Ordering;
+                let mut i = self.next_write_index.load(Ordering::Relaxed);
+                loop {
+                    let short_id = generate_short_id(&self.shared_secret, i);
+                    let status =
+                        write_mailbox(self.services, self.ohttp_keys, short_id, &message).await?;
+                    match status {
+                        http::StatusCode::OK => {
+                            // Advance the local hint past the slot we just claimed.
+                            self.next_write_index.fetch_max(i + 1, Ordering::Relaxed);
+                            return Ok(());
+                        }
+                        http::StatusCode::CONFLICT => {
+                            i += 1;
+                        }
+                        other =>
+                            return Err(format!("unexpected post_mailbox status: {}", other).into()),
+                    }
+                }
+            }
+
+            fn read(&self) -> Self::Messages<'_> {
+                let secret = self.shared_secret;
+                let services = self.services;
+                let keys = self.ohttp_keys;
+                Box::pin(async_stream::stream! {
+                    let mut i = 0u64;
+                    loop {
+                        let short_id = generate_short_id(&secret, i);
+                        match read_mailbox(services, keys, short_id).await {
+                            Ok(Some(payload)) => {
+                                yield Ok(payload);
+                                i += 1;
+                            }
+                            // Local timeout: no payload at this slot. Could be true end-of-log.
+                            Ok(None) => break,
+                            Err(e) => {
+                                yield Err(e);
+                                break;
+                            }
+                        }
+                    }
+                })
+            }
+        }
+
         async fn do_linked_mailbox_test(services: &TestServices) -> Result<(), BoxSendSyncError> {
+            use futures::StreamExt;
+
             services.wait_for_services_ready().await?;
             let ohttp_keys = services.fetch_ohttp_keys().await?;
-
             let shared_secret = secp256k1::SecretKey::new(&mut OsRng).secret_bytes();
-            let short_id_0 = generate_short_id(&shared_secret, 0);
-            let short_id_1 = generate_short_id(&shared_secret, 1);
-            let short_id_2 = generate_short_id(&shared_secret, 2);
-            assert_ne!(short_id_0, short_id_1);
-            assert_ne!(short_id_1, short_id_2);
-            assert_ne!(short_id_0, short_id_2);
 
-            let alice_msg: &[u8] = b"Hello from Alice";
-            let bob_msg: &[u8] = b"Hello from Bob";
-            let carol_msg: &[u8] = b"Hello from Carol";
+            // Each peer is independently initialized with only the shared secret.
+            let alice = DirectoryLinkedMailbox::new(services, &ohttp_keys, shared_secret);
+            let bob = DirectoryLinkedMailbox::new(services, &ohttp_keys, shared_secret);
+            let carol = DirectoryLinkedMailbox::new(services, &ohttp_keys, shared_secret);
 
-            write_mailbox(services, &ohttp_keys, short_id_0, alice_msg).await?;
-            write_mailbox(services, &ohttp_keys, short_id_1, bob_msg).await?;
-            write_mailbox(services, &ohttp_keys, short_id_2, carol_msg).await?;
+            let alice_msg = b"Hello from Alice".to_vec();
+            let bob_msg = b"Hello from Bob".to_vec();
+            let carol_msg = b"Hello from Carol".to_vec();
 
-            let alice_read = read_mailbox(services, &ohttp_keys, short_id_0)
-                .await?
-                .ok_or("Alice's mailbox should have a payload")?;
-            let bob_read = read_mailbox(services, &ohttp_keys, short_id_1)
-                .await?
-                .ok_or("Bob's mailbox should have a payload")?;
-            let carol_read = read_mailbox(services, &ohttp_keys, short_id_2)
-                .await?
-                .ok_or("Carol's mailbox should have a payload")?;
+            let (ra, rb, rc) = tokio::join!(
+                alice.write(alice_msg.clone()),
+                bob.write(bob_msg.clone()),
+                carol.write(carol_msg.clone()),
+            );
+            ra?;
+            rb?;
+            rc?;
 
-            assert_eq!(alice_read, alice_msg);
-            assert_eq!(bob_read, bob_msg);
-            assert_eq!(carol_read, carol_msg);
+            // Any peer (with the same secret) can iterate the full message
+            // set. Server-side ordering is opaque, so compare as a set.
+            let stream = alice.read();
+            tokio::pin!(stream);
+            let mut observed = Vec::new();
+            while let Some(item) = stream.next().await {
+                observed.push(item?);
+            }
+            assert_eq!(observed.len(), 3, "reader should see all three appended messages");
 
-            // An unrelated short_id (different shared secret) should have no payload posted.
+            use std::collections::HashSet;
+            let expected: HashSet<Vec<u8>> = [alice_msg, bob_msg, carol_msg].into_iter().collect();
+            let observed_set: HashSet<Vec<u8>> = observed.into_iter().collect();
+            assert_eq!(observed_set, expected);
+
+            // A peer initialized with a different secret sees an empty message set.
             let other_secret = secp256k1::SecretKey::new(&mut OsRng).secret_bytes();
-            let other_short_id = generate_short_id(&other_secret, 0);
-            let empty = read_mailbox(services, &ohttp_keys, other_short_id).await?;
-            assert!(empty.is_none(), "unrelated mailbox should be empty");
+            let stranger = DirectoryLinkedMailbox::new(services, &ohttp_keys, other_secret);
+            let stranger_stream = stranger.read();
+            tokio::pin!(stranger_stream);
+            assert!(stranger_stream.next().await.is_none(), "unrelated message set must be empty");
 
             Ok(())
         }
@@ -376,8 +492,8 @@ mod integration {
         async fn test_create_linked_mailbox() -> Result<(), BoxSendSyncError> {
             init_tracing();
             let mut services = TestServices::initialize().await?;
-            // 3 peers write to a linked sequence of mailboxes whose short_ids are
-            // derived as short_id = H(shared_secret, i) for i = 0..n.
+            // Three peers each hold an independent CollaborativeMessageSet
+            // handle initialized only with the shared secret.
             let result = tokio::select!(
                 err = services.take_ohttp_relay_handle() => panic!("Ohttp relay exited early: {:?}", err),
                 err = services.take_directory_handle() => panic!("Directory server exited early: {:?}", err),


### PR DESCRIPTION
Test that multiple parties can use deterministically linked mailboxes derived from a shared secret using H(shared_secret, index) pattern.

cc: @arminsabouri @nothingmuch
